### PR TITLE
Topic/add b format info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A number of 30 second extracts from published and unpublished recordings.
 
+Files in the "b-format" folder are traditional first-order B-format recordings, which use the Furse-Malham component ordering (WXYZ) and MaxN normalization schemes, and which have a wavefield-encoded radial distance of infinity. They can be directly decoded using the FoaDecode UGen, in combination with a suitable decoder object, such as FoaDecoderMatrix.newStereo.
+
 ## Using the example files with Reaper
 
 These example files are not required in order for ATK for Reaper to work, but they may come in handy when testing the various encoders, transformers and decorders in Reaper projects.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sound Examples for the Ambisonic Toolkit
 
 A number of 30 second extracts from published and unpublished recordings.
+ATK for SuperCollider users are strongly advised to download and install these files.
 
 ## Using the example files with Reaper
 
@@ -23,6 +24,5 @@ Atk.openUserSupportDir;
 
 If the ATK has been correctly installed, the above code will open the ATK's user support directory. Place the downloaded soundfiles here.
 
-Files in the "b-format" folder are traditional first-order B-format recordings, which use the Furse-Malham component ordering (WXYZ) and MaxN normalization scheme, and which have a wavefield-encoded radial distance of infinity. They can be directly decoded using the FoaDecode UGen, in combination with a suitable decoder object, such as FoaDecoderMatrix.newStereo.
-
-*Note:* ATK for SuperCollider users are strongly advised to download and install these files.
+> [!NOTE]  
+> Files in the "b-format" folder are traditional first-order B-format recordings, which use the Furse-Malham component ordering (WXYZ) and MaxN normalization scheme, and which have a wavefield-encoded radial distance of infinity. They can be directly decoded using the `FoaDecode` UGen, in combination with a suitable decoder object, such as `FoaDecoderMatrix.newStereo`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A number of 30 second extracts from published and unpublished recordings.
 
-Files in the "b-format" folder are traditional first-order B-format recordings, which use the Furse-Malham component ordering (WXYZ) and MaxN normalization schemes, and which have a wavefield-encoded radial distance of infinity. They can be directly decoded using the FoaDecode UGen, in combination with a suitable decoder object, such as FoaDecoderMatrix.newStereo.
-
 ## Using the example files with Reaper
 
 These example files are not required in order for ATK for Reaper to work, but they may come in handy when testing the various encoders, transformers and decorders in Reaper projects.
@@ -23,7 +21,8 @@ Atk.openUserSupportDir;
 )
 ```
 
-
 If the ATK has been correctly installed, the above code will open the ATK's user support directory. Place the downloaded soundfiles here.
+
+Files in the "b-format" folder are traditional first-order B-format recordings, which use the Furse-Malham component ordering (WXYZ) and MaxN normalization scheme, and which have a wavefield-encoded radial distance of infinity. They can be directly decoded using the FoaDecode UGen, in combination with a suitable decoder object, such as FoaDecoderMatrix.newStereo.
 
 *Note:* ATK for SuperCollider users are strongly advised to download and install these files.


### PR DESCRIPTION
It may be helpful if specific information about files in the "b-format" folder were included in the README file (specifically to do with Ambisonic order, component ordering, normalization, and encoding radius), to make the converting/decoding process as unambiguous as possible. Some language is suggested in this PR as a starting point, feel free to reword it, move it elsewhere in the README, etc.

It might also be appropriate to add similar language about the "a-format" files, since there may be even more ambiguity here regarding the tetrahedral orientation and conversion/decoding process. Proposed language for these files is not included here, because I'm not fully aware of these specific details.